### PR TITLE
Fix default export

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+lib/*.spec.*
+*.spec.js
+lunr.unicodeNormalizer.js
+lunr.unicodeNormalizer.ts
+*.spec.ts

--- a/lunr.unicodeNormalizer.ts
+++ b/lunr.unicodeNormalizer.ts
@@ -101,7 +101,7 @@ function unicodeFolder(str: string) {
   });
 }
 
-export default function patchLunr(lunrmod: any) {
+function patchLunr(lunrmod: any) {
   var tokenizer = function(obj: any, metadata: any) {
     if (!arguments.length || obj === null || obj === undefined) return [];
     if (Array.isArray(obj)) {
@@ -145,3 +145,7 @@ export default function patchLunr(lunrmod: any) {
   }
   lunrmod.tokenizer = tokenizer;
 }
+
+// Nasty and mysterious hack to make CommonJS and TS and ES imports work
+patchLunr.default = patchLunr;
+export = patchLunr;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunr-folding",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Simple character folding for lunr.js",
   "main": "lib/lunr.unicodeNormalizer.js",
   "types": "lib/lunr.unicodeNormalizer.d.ts",


### PR DESCRIPTION
Seems that the documentation was wrong for CommonJS because of what TypeScript generates for `export default`.

This works, not sure why, but it works.